### PR TITLE
Addition of a step to filter out suspended accounts from list_members results

### DIFF
--- a/UpdateMembers/template.yaml
+++ b/UpdateMembers/template.yaml
@@ -97,6 +97,7 @@ Resources:
                 - securityhub:Get*
                 - securityhub:List*
                 - securityhub:Describe*
+                - organizations:ListAccounts
               Resource: "*"
             - Effect: Allow
               Action:


### PR DESCRIPTION

*Issue #8:*

The challenge that this pull request tries to solve is probably related to the issue although I can not make sure because it does not elaborate the details.

*Description of changes:*

## What is an issue?

This pull request tries to improve robustness against situation where any of Security member accounts were suspended.

This tool uses list_members API to determine target accounts in [get_members](https://github.com/aws-samples/aws-security-hub-cross-account-controls-disabler/blob/main/UpdateMembers/src/GetMembers/index.py#L92) function.
By default this API returns a list of Security Hub member accounts with "Enabled" status as described in boto3 [reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/securityhub/client/list_members.html).

However, suspended accounts are also shown as "Enabled" in list_members results and we cannot tell which are suspended accounts.
So Step Functions may produce error when there exist any suspended account in target list.

## How it is resolved?

This pull request includes update to use [list_accounts](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/organizations/client/list_accounts.html) to tell active(not suspended) accounts and filter out suspended accounts from target list.
Delegate administrator accounts can use ListAccounts API as explained in [API reference](https://docs.aws.amazon.com/organizations/latest/APIReference/action-reference.html#actions-management-or-delegated-admin).

[Disassociating](https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_DisassociateMembers.html) such suspended accounts also works as workaround.
Disassociated accounts' status should turn into "Removed" and thus not appear in list_members result by default.
But it is preferable to filter out suspended accounts explicitly from the point of view of robustness.

## Changes

- Added get_active_accounts function to create a list of active accounts.
- Added a step to filter out suspended accounts from list_member results.
- Added organizations:ListAccounts permission to Lambda execution role.

## Test

I confirmed pytest test successfully completes.
Also I tested my version of tool in my test accounts.

Test steps are following.

1. Create Security Hub multi accounts environment with delegated administrator.

AdminAccount: Security Hub delegated administrator account
SecHubMember1: Organization member account with Security Hub enabled by the delegated admin
SecHubMember2: same
SecHubMember3: same

2. Confirm all the accounts' Security Hub MemberStatus is "Enabled" by AWS CLI list-members command.

3. Confirm all the accounts' status is "ACTIVE" and not "SUSPENDED" by AWS CLI list-accounts command.

4. Deploy my version of the tool.

5. Confirm that controls disabled in AdminAccount are disabled by Step Function state machine.

6. Suspend SecHubMember1 by CloseAccount API.

7. Confirm that SecHubMember1 is successfully closed("SUSPENDED") by AWS CLI list-members command.

8. Confirm that SecHubMember1 is still shown as "Enabled" by AWS CLI list-members command.

9. Disable a control in AdminAccount.

10. Confirm that the control is also disabled in the member accounts other than SecHubMember1.

11. Check state machine log and confirm that SecHubMember1 is not included in target accounts(Payload.accounts).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.