### PR TITLE
chore: update python runtime version

### DIFF
--- a/UpdateMembers/template.yaml
+++ b/UpdateMembers/template.yaml
@@ -116,7 +116,7 @@ Resources:
         Fn::GetAtt:
         - LambdaExecutionRole
         - Arn
-      Runtime: python3.8
+      Runtime: python3.11
       Timeout: 300
 
   GetMembers:
@@ -129,7 +129,7 @@ Resources:
         Fn::GetAtt:
         - LambdaExecutionRole
         - Arn
-      Runtime: python3.8
+      Runtime: python3.11
       Timeout: 300
       Environment:
         Variables:
@@ -146,7 +146,7 @@ Resources:
         Fn::GetAtt:
         - LambdaExecutionRole
         - Arn
-      Runtime: python3.8
+      Runtime: python3.11
       Timeout: 900
       Environment:
         Variables:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/aws-security-hub-cross-account-controls-disabler/issues/18

*Description of changes:*
Upgrade to the version of the Python runtime used by Lambda, as version 3.8 of the Python runtime for Lambda will be retired on October 14, 2024.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
